### PR TITLE
Change from get to post

### DIFF
--- a/pages/api/navigation.ts
+++ b/pages/api/navigation.ts
@@ -40,10 +40,10 @@ const navigationLinks = async (req, res) => {
 const handler = async (req, res) => {
   const { method } = req;
   switch (method) {
-    case "GET":
+    case "POST":
       return navigationLinks(req, res);
     default:
-      res.setHeader("Allow", ["GET", "OPTIONS"]);
+      res.setHeader("Allow", ["POST", "OPTIONS"]);
       res.status(405).end(`Method ${method} Not Allowed`);
   }
 };


### PR DESCRIPTION
The `navigationLinks` endpoint is a POST for body params but the internal call to strapi is a GET. The cors needs to allow POST not GET in this case