### PR TITLE
Remove pagination on ecosystem request

### DIFF
--- a/pages/ecosystem.tsx
+++ b/pages/ecosystem.tsx
@@ -140,13 +140,16 @@ const Ecosystem = ({ seo, navLinks, partners }) => {
 };
 
 export async function getStaticProps() {
-  const partnerRes = await fetchAPI("/oeth-partners", {
-    populate: {
-      logo: {
-        populate: "*",
+  const partnerRes = await fetchAPI(
+    "/oeth-partners?pagination[pageSize]=1000",
+    {
+      populate: {
+        logo: {
+          populate: "*",
+        },
       },
-    },
-  });
+    }
+  );
   const seoRes = await fetchAPI("/oeth/page/en/%2Fecosystem");
   const navRes = await fetchAPI("/oeth-nav-links", {
     populate: {

--- a/utils/api/fetchAPI.ts
+++ b/utils/api/fetchAPI.ts
@@ -23,7 +23,9 @@ export async function fetchAPI(path = "", urlParamsObject = {}, options = {}) {
   const queryString = qs.stringify(urlParamsObject);
 
   const requestUrl = `${getStrapiURL(
-    `/api${path}${queryString ? `?${queryString}` : ""}`
+    `/api${path}${
+      queryString ? `${path.includes("?") ? "&" : "?"}` + `${queryString}` : ""
+    }`
   )}`;
 
   // Trigger API call


### PR DESCRIPTION
The ecosystem page was not populating all items from cms because of pagination. The frontend was not designed with pagination so it left many items from cms out. I have removed the pagination for now and it shouldn't affect load times since we statically build the page. 

We can revisit pagination if problems arise from this.

Closes #94 