### PR TITLE
Clean up PoY 0.75 copy

### DIFF
--- a/components/proof-of-yield/YieldBoostMultiplier.tsx
+++ b/components/proof-of-yield/YieldBoostMultiplier.tsx
@@ -19,7 +19,7 @@ const YieldBoostMultiplier = ({
           textClassName="text-white text-base md:text-xl mr-1"
           whiteTooltip={true}
         >
-          Yield Bonus
+          Yield bonus
         </TitleWithInfo>
       </div>
       <div className="border md:border-2 mx-4 md:mx-8 border-origin-bg-black px-4 md:px-6 py-4 mt-6 rounded-t-lg flex flex-col 2xl:flex-row 2xl:justify-between 2xl:items-center">
@@ -41,11 +41,11 @@ const YieldBoostMultiplier = ({
           <Typography.Body className="inline mr-1">
             {commifyToDecimalPlaces(boost, 2)}
           </Typography.Body>
-          <Typography.Body2 className="inline">Boost</Typography.Body2>
+          <Typography.Body2 className="inline">Multiplier</Typography.Body2>
         </div>
         <div className="max-w-[60%]">
           <Typography.Body3 className="text-table-title text-sm text-left 2xl:text-right">
-            OETH total supply ÷ Rebasing OETH supply
+            Total supply / yield-earning supply
           </Typography.Body3>
         </div>
       </div>
@@ -60,7 +60,7 @@ const YieldBoostMultiplier = ({
         </div>
         <div>
           <Typography.Body3 className="text-table-title text-sm text-left 2xl:text-right">
-            Distributed APY
+            Actual yield distributed
           </Typography.Body3>
         </div>
       </div>

--- a/components/proof-of-yield/YieldBoostMultiplier.tsx
+++ b/components/proof-of-yield/YieldBoostMultiplier.tsx
@@ -43,7 +43,7 @@ const YieldBoostMultiplier = ({
           </Typography.Body>
           <Typography.Body2 className="inline">Multiplier</Typography.Body2>
         </div>
-        <div className="max-w-[60%]">
+        <div>
           <Typography.Body3 className="text-table-title text-sm text-left 2xl:text-right">
             Total supply / yield-earning supply
           </Typography.Body3>

--- a/sections/proof-of-yield/DailyYield.tsx
+++ b/sections/proof-of-yield/DailyYield.tsx
@@ -81,7 +81,7 @@ const DailyYield = ({ dailyStats }: DailyYieldProps) => {
               info={`The annualized, compounded rate earned by OETH holders on this day`}
               className="pr-4 sm:pr-8 lg:pr-14 xl:pr-24"
             >
-              APY
+              Daily APY
             </TableHead>
             {width >= smSize && (
               <TableHead

--- a/sections/proof-of-yield/DayBasicData.tsx
+++ b/sections/proof-of-yield/DayBasicData.tsx
@@ -158,18 +158,9 @@ const DayBasicData = ({
                     Block / Time
                   </TableHead>
                   {width >= smSize ? (
-                    <>
-                      <TableHead
-                        align="left"
-                        className={eventChartColumnCssLeft}
-                      >
-                        Action
-                      </TableHead>
-
-                      <TableHead className={eventChartColumnCssRight}>
-                        Amount
-                      </TableHead>
-                    </>
+                    <TableHead className={eventChartColumnCssRight}>
+                      Amount
+                    </TableHead>
                   ) : (
                     <TableHead
                       className={twMerge(
@@ -177,7 +168,7 @@ const DayBasicData = ({
                         "whitespace-normal pr-4"
                       )}
                     >
-                      Amount / Action
+                      Amount
                     </TableHead>
                   )}
                   <TableHead
@@ -208,17 +199,9 @@ const DayBasicData = ({
                       </Typography.Body3>
                     </TableData>
                     {width >= smSize ? (
-                      <>
-                        <TableData
-                          align="left"
-                          className={eventChartColumnCssLeft}
-                        >
-                          {`Rebase`}
-                        </TableData>
-                        <TableData className={eventChartColumnCssRight}>
-                          {commifyToDecimalPlaces(parseFloat(item.amount), 4)}
-                        </TableData>
-                      </>
+                      <TableData className={eventChartColumnCssRight}>
+                        {commifyToDecimalPlaces(parseFloat(item.amount), 4)}
+                      </TableData>
                     ) : (
                       <TableData
                         className={twMerge(
@@ -228,9 +211,6 @@ const DayBasicData = ({
                       >
                         <Typography.Body3 className="text-xs md:text-base text-table-data">
                           {commifyToDecimalPlaces(parseFloat(item.amount), 4)}
-                        </Typography.Body3>
-                        <Typography.Body3 className="text-xs md:text-sm text-table-title">
-                          {`Rebase`}
                         </Typography.Body3>
                       </TableData>
                     )}


### PR DESCRIPTION
This updates some text and removes an excess column from the yield event history table.