### PR TITLE
Fix safari datetime

### DIFF
--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -222,9 +222,11 @@ export const sumOf = (data) => {
   }, 0);
 };
 
-const formatMonthDay = (d) => format(new Date(d), "MMM do");
+const formatMonthDay = (d) => {
+  return format(new Date(d.slice(0, 10)), "MMM do");
+};
 
-export const formatLabels = (labels) => labels?.map(formatMonthDay);
+export const formatLabels = (labels) => labels?.map(formatMonthDay) || [];
 
 export const formatDisplay = ({ labels, datasets }) => ({
   labels: labels ? formatLabels(labels) : [],


### PR DESCRIPTION
**Description:**
Fixes an issue with the way Safari handles parsing ISO date times within `date-fns`

Works in chrome but does not work in iOS safari
```
new Date('2023-05-06 00:00:00.000 UTC') as Fri May 05 2023 20:00:00 GMT-0400 (Eastern Daylight Time)
```

**Fix:**
Strip out the timestamp portion as we deal with date/month format either way


