### PR TITLE
Use fixed height & width ratio for rpool

### DIFF
--- a/sections/homepage/Allocation.tsx
+++ b/sections/homepage/Allocation.tsx
@@ -204,18 +204,18 @@ const Allocation = ({ strategies }: AllocationProps) => {
                                           className="flex flex-row justify-between xl:mr-10 xl:pt-2.5"
                                           key={i}
                                         >
-                                          <div className="flex flex-row">
+                                          <div className="flex flex-row items-center">
                                             <div
                                               className={`relative ${
                                                 strategy?.protocol === "Convex"
-                                                  ? "w-12"
-                                                  : "w-6"
+                                                  ? "w-[48px] h-[24px]"
+                                                  : "w-[24px] h-[24px]"
                                               }`}
                                             >
                                               <Image
                                                 src={strategy?.icon}
-                                                fill
                                                 alt={strategy.name}
+                                                fill
                                               />
                                             </div>
                                             <Typography.Body3 className="pl-[12px] pr-[16px] font-light text-[12px] md:text-[16px]">


### PR DESCRIPTION
* Fixes a rendering issue with logos in mobile viewport

**Previous**
![IMG_4492](https://github.com/OriginProtocol/oeth.com/assets/762107/afa015e7-62a6-45ff-9195-8d16016f5b4f)

**Fixed**
![Screenshot 2023-07-18 175202](https://github.com/OriginProtocol/oeth.com/assets/762107/9a2d6613-8dc3-42be-91bb-0d52e86b5aec)
