### PR TITLE
Redirect Origin DeFi pages to ousd.com

### DIFF
--- a/pages/governance.tsx
+++ b/pages/governance.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+const Governance: React.FC = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push('https://ousd.com/governance');
+  }, []);
+
+  return null;
+};
+
+export async function getServerSideProps(context: any) {
+  if (context.res) {
+    context.res.writeHead(302, { Location: 'https://ousd.com/governance' });
+    context.res.end();
+  }
+
+  return {};
+}
+
+export default Governance;

--- a/pages/ogv-dashboard.tsx
+++ b/pages/ogv-dashboard.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+const OgvDashboard: React.FC = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push('https://ousd.com/ogv-dashboard');
+  }, []);
+
+  return null;
+};
+
+export async function getServerSideProps(context: any) {
+  if (context.res) {
+    context.res.writeHead(302, { Location: 'https://ousd.com/ogv-dashboard' });
+    context.res.end();
+  }
+
+  return {};
+}
+
+export default OgvDashboard;


### PR DESCRIPTION
This may not be the ideal way to accomplish this, but it's better than the status quo. See https://github.com/OriginProtocol/oeth.com/issues/98 (+ OGV dashboard).